### PR TITLE
Double image drag behavior

### DIFF
--- a/src/components/AlbumDetailView.vue
+++ b/src/components/AlbumDetailView.vue
@@ -21,7 +21,6 @@
             class="drop-zone-wrapper">
             <div>
               <DropZoneLine
-                v-if="!currentFolderElement || !currentFolderElement.endsWith('doubleImg')"
                 :drag-start-element="currentFolderElement"
                 :idx="idx" />
             </div>
@@ -40,7 +39,6 @@
               @switch-images="switchImages" />
             <div>
               <DropZoneLine
-                v-if="!currentFolderElement || !currentFolderElement.endsWith('doubleImg')"
                 :drag-start-element="currentFolderElement"
                 :idx="idx + 1" />
             </div>

--- a/src/components/BaseSlideBox/BaseSlideBox.vue
+++ b/src/components/BaseSlideBox/BaseSlideBox.vue
@@ -4,8 +4,7 @@
     <BaseBox
       :id="`${id}-${slides[0].id}`"
       ref="baseBox"
-      :box-size="{ width: 'unset' }"
-      @dragleave.native="onDragLeave($event)">
+      :box-size="{ width: 'unset' }">
       <div v-if="slides.length === 1">
         <div>
           <div
@@ -137,11 +136,6 @@ export default {
     },
   },
   methods: {
-    onDragLeave(ev) {
-      ev.preventDefault();
-      ev.stopPropagation();
-      console.log('Drag leave', ev);
-    },
     onEnd(ev) {
       // console.log(this.id);
       // console.log('onEnd Event:', ev, this.slides);

--- a/src/components/BaseSlideBox/BaseSlideBox.vue
+++ b/src/components/BaseSlideBox/BaseSlideBox.vue
@@ -4,7 +4,8 @@
     <BaseBox
       :id="`${id}-${slides[0].id}`"
       ref="baseBox"
-      :box-size="{ width: 'unset' }">
+      :box-size="{ width: 'unset' }"
+      @dragleave.native="onDragLeave($event)">
       <div v-if="slides.length === 1">
         <div>
           <div
@@ -136,6 +137,11 @@ export default {
     },
   },
   methods: {
+    onDragLeave(ev) {
+      ev.preventDefault();
+      ev.stopPropagation();
+      console.log('Drag leave', ev);
+    },
     onEnd(ev) {
       // console.log(this.id);
       // console.log('onEnd Event:', ev, this.slides);

--- a/src/components/BaseSlideBox/PlaceholderZone.vue
+++ b/src/components/BaseSlideBox/PlaceholderZone.vue
@@ -67,8 +67,8 @@ export default {
   background: rgba(0, 0, 0, 0);
   z-index: 2;
   text-align: center;
-    align-content: center;
-    color: transparent;
+  align-content: center;
+  color: transparent;
 }
 
 .image-wrapper.drag-drop-overlay {

--- a/src/components/DragAndDrop.vue
+++ b/src/components/DragAndDrop.vue
@@ -3,46 +3,57 @@
     <div v-if="album != null">
       <div class="workfolder-title">
         <small>Arbeitsmappe</small>
-        <h1 class="title">{{album.title}}</h1>
+        <h1 class="title">
+          {{ album.title }}
+        </h1>
       </div>
       <div>
-        <ButtonMenu></ButtonMenu>
+        <ButtonMenu />
       </div>
       <div>
         <div class="drag-drop-wrapper">
-          <draggable class="draggable-list" :object="album" group="my-group" :animation="300" ...>
-            <div class="list-item" v-for="element in album.items" :key="element.id">
-              <BaseImageBox class="image-wrapper"
-                            :box-size="{ width: 'unset' }"
-                            :image-url="element.imageUrl"
-                            :title="element.title"
-                            :subtext="element.subtext"
-                            :description="element.description">
-                <img class="box-image" :src="element.imageUrl" alt="">
+          <draggable
+            class="draggable-list"
+            :object="album"
+            group="my-group"
+            :animation="300"
+            ...>
+            <div
+              v-for="element in album.items"
+              :key="element.id"
+              class="list-item">
+              <BaseImageBox
+                class="image-wrapper"
+                :box-size="{ width: 'unset' }"
+                :image-url="element.imageUrl"
+                :title="element.title"
+                :subtext="element.subtext"
+                :description="element.description">
+                <img
+                  class="box-image"
+                  :src="element.imageUrl"
+                  alt="">
               </BaseImageBox>
             </div>
             <base-box-button
-                icon="plus"
-                text="Neues Kunstwerk zur Arbeitsmappe hinzufügen"
-                :show-title="false"
-                :box-size="{ width: 'unset' }"
-                class="box">
-            </base-box-button>
+              icon="plus"
+              text="Neues Kunstwerk zur Arbeitsmappe hinzufügen"
+              :show-title="false"
+              :box-size="{ width: 'unset' }"
+              class="box" />
             <base-box-button
-                icon="download"
-                text="Arbeitsmappe herunterladen"
-                :show-title="false"
-                :box-size="{ width: 'unset' }"
-                class="box">
-            </base-box-button>
+              icon="download"
+              text="Arbeitsmappe herunterladen"
+              :show-title="false"
+              :box-size="{ width: 'unset' }"
+              class="box" />
             <base-box-button
-                icon="people"
-                box-style="large"
-                text="Personen zum Bearbeiten einladen"
-                :show-title="false"
-                :box-size="{ width: 'unset' }"
-                class="box">
-            </base-box-button>
+              icon="people"
+              box-style="large"
+              text="Personen zum Bearbeiten einladen"
+              :show-title="false"
+              :box-size="{ width: 'unset' }"
+              class="box" />
           </draggable>
         </div>
       </div>
@@ -54,14 +65,14 @@
 </template>
 
 <script>
-import ButtonMenu from "@/components/ButtonMenu.vue";
-import {albums} from "@/albums";
-import draggable from "vuedraggable";
-import BaseSlideBox from "@/components/BaseSlideBox/BaseSlideBox.vue";
+import ButtonMenu from '@/components/ButtonMenu.vue';
+import { albums } from '@/albums';
+import draggable from 'vuedraggable';
+import BaseSlideBox from '@/components/BaseSlideBox/BaseSlideBox.vue';
 
 export default {
-  name: "AlbumDetailView",
-  components: {BaseSlideBox, ButtonMenu, draggable},
+  name: 'AlbumDetailView',
+  components: { BaseSlideBox, ButtonMenu, draggable },
   data() {
     return {
       albums,
@@ -69,13 +80,11 @@ export default {
   },
   computed: {
     album() {
-      let albumID = Number(this.$route.params.id);
-      return this.albums.find((album) =>  {
-        return album.album_id === albumID
-      })
-    }
-  }
-}
+      const albumID = Number(this.$route.params.id);
+      return this.albums.find(album => album.album_id === albumID);
+    },
+  },
+};
 </script>
 
 <style scoped>


### PR DESCRIPTION
This PR should fix issue #12 . Due to limitations in the Drag and Drop API, the image shown while dragging a DoubleImage cannot be changed to look like a full BaseSlideBox when dragging the DoubleImage outside its folder (https://stackoverflow.com/a/48214040). The functionality of reordering the folders is now given, but the appearance might not yet be ideal (see image below). 
![image](https://user-images.githubusercontent.com/37192329/224302746-41b5f0dd-a988-459b-aef3-7d85ff5aa208.png)
